### PR TITLE
Reset ScopedTimer hierarchy when clearing summaries

### DIFF
--- a/active_adaptation/utils/profiling.py
+++ b/active_adaptation/utils/profiling.py
@@ -95,6 +95,19 @@ class ScopedTimer(_DecoratorContextManager):
             root.print_recursive(root, 0, clear=clear, max_depth=depth, total_time=total_time)
 
         print("=" * 70 + "\n")
+        if clear:
+            ScopedTimer.clear()
+
+    @staticmethod
+    def clear():
+        """Clear timing values and hierarchy so timer names can be reused elsewhere."""
+        for timer in ScopedTimer._instances.values():
+            timer.time = 0.0
+            timer.count = 0
+            timer.children.clear()
+            timer.parent = None
+        ScopedTimer._root_nodes.clear()
+        ScopedTimer._stack.clear()
 
     def print_recursive(self, node: "ScopedTimer", depth: int = 0, clear: bool = True, max_depth: int = -1, total_time: float = 0.0):
         """Recursively print timer nodes in DFS order."""
@@ -112,4 +125,3 @@ class ScopedTimer(_DecoratorContextManager):
 
         for child in node.children:
             self.print_recursive(child, depth + 1, clear=clear, max_depth=max_depth, total_time=total_time)
-

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -1,0 +1,31 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+
+from active_adaptation.utils.profiling import ScopedTimer
+
+
+class ScopedTimerTest(unittest.TestCase):
+    def setUp(self):
+        ScopedTimer.clear()
+
+    def tearDown(self):
+        ScopedTimer.clear()
+
+    def test_clear_allows_a_timer_to_be_reused_under_a_new_parent(self):
+        with ScopedTimer("rollout"):
+            with ScopedTimer("simulation"):
+                pass
+
+        with redirect_stdout(io.StringIO()):
+            ScopedTimer.print_summary(clear=True)
+
+        with ScopedTimer("evaluation") as evaluation:
+            with ScopedTimer("simulation") as simulation:
+                pass
+
+        self.assertIs(simulation.parent, evaluation)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #16

## Summary

- clear timer hierarchy state when `print_summary(clear=True)` is called
- allow timer names to be reused under a different parent
- add a regression test for rollout-to-evaluation reparenting

## Root cause

`print_summary(clear=True)` reset timing values but kept each timer's parent and children. Because `ScopedTimer` reuses instances by name, evaluation could not reuse `simulation` outside its training-time `rollout` parent.

## Validation

- minimal profiler reproduction passes
- regression test passes in the IsaacLab environment
- short PPO resume completed one training iteration and the full 900-step final evaluation without the reparenting exception

## Scope

This change only affects profiler cleanup. It does not change policy state, observations, actions, rewards, checkpoints, or simulator behavior.
